### PR TITLE
Fixes #59 - allows headers to the set on the connection

### DIFF
--- a/SignalR.Client/SRConnection.h
+++ b/SignalR.Client/SRConnection.h
@@ -47,6 +47,7 @@ typedef void (^onReconnected)();
 @property (strong, nonatomic, readwrite) NSMutableDictionary *items;
 @property (strong, nonatomic, readonly) NSString *queryString;
 @property (assign, nonatomic, readonly) BOOL initialized;
+@property (strong, nonatomic, readonly) NSMutableDictionary *headers;
 
 @property (nonatomic, assign) id<SRConnectionDelegate> delegate;
 
@@ -66,6 +67,7 @@ typedef void (^onReconnected)();
 - (void)didReceiveData:(NSString *)data;
 - (void)didReceiveError:(NSError *)ex;
 - (void)didReconnect;
+- (void)setHeader:(NSString *)header toValue:(NSString *)value;
 
 - (void)prepareRequest:(id)request;
 - (NSString *)createUserAgentString:(NSString *)client;

--- a/SignalR.Client/SRConnection.m
+++ b/SignalR.Client/SRConnection.m
@@ -53,6 +53,7 @@ void (^prepareRequest)(id);
 @synthesize connectionId = _connectionId;
 @synthesize items = _items;
 @synthesize queryString = _queryString;
+@synthesize headers = _headers;
 
 @synthesize delegate = _delegate;
 
@@ -102,6 +103,7 @@ void (^prepareRequest)(id);
         _queryString = queryString;
         _groups = [[NSMutableArray alloc] init];
         _items = [NSMutableDictionary dictionary];
+        _headers = [NSMutableDictionary dictionary];
     }
     return self;
 }
@@ -300,6 +302,12 @@ void (^prepareRequest)(id);
     }
 }
 
+
+- (void) setHeader:(NSString *)header toValue:(NSString *)value
+{
+    [_headers setValue:value forKey:header];
+}
+
 #pragma mark - 
 #pragma mark Prepare Request
 
@@ -320,6 +328,10 @@ void (^prepareRequest)(id);
             
             //Set the Authorization header that we just generated to our actual request
             [request addValue:[clientForAuthHeader defaultValueForHeader:@"Authorization"] forHTTPHeaderField:@"Authorization"];
+        }
+        for(NSString *header in _headers) 
+        {
+            [request addValue:[_headers valueForKey:header] forHTTPHeaderField:header];
         }
     }
 }


### PR DESCRIPTION
This adds support for custom headers. Current implementation allows any header to be set, which seems pretty reasonable to me. This might also allow things like browser agents to be set by the program.
