### PR TITLE
Fixes #62, extra arguments sent from the server cause background thread ...

### DIFF
--- a/SignalR.Client/Hubs/SRHubProxy.m
+++ b/SignalR.Client/Hubs/SRHubProxy.m
@@ -78,9 +78,19 @@
     {
         NSMethodSignature *signature = [eventObj.object methodSignatureForSelector:eventObj.selector];
         NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+        NSUInteger signatureNumArgs = [signature numberOfArguments] - 2;
+        
+        BOOL differentNumberOfAruments = args.count != signatureNumArgs;
+        if (differentNumberOfAruments)
+        {
+#if DEBUG_SERVER_SENT_EVENTS || DEBUG_LONG_POLLING || DEBUG_HTTP_BASED_TRANSPORT
+            SR_DEBUG_LOG(@"[HTTP_BASED_TRANSPORT] Callback for event '%@' is configured with %d arguments, received %d parameters instead.",eventName, signatureNumArgs, args.count);
+#endif            
+        }
+        
         [invocation setSelector:eventObj.selector];
         [invocation setTarget:eventObj.object];
-        for(int i =0; i<[args count]; i++)
+        for(int i =0; i< MIN([args count], [signature numberOfArguments] - 2); i++)
         {
             int arguementIndex = 2 + i;
             __unsafe_unretained NSString *argument = [args objectAtIndex:i];


### PR DESCRIPTION
Added a fix so that extra parameters are disregarded and a warning is printed in the console about the mismatch.
