### PR TITLE
SRHubConnection callback fixes.

### DIFF
--- a/SignalR.Client/Hubs/SRHubConnection.m
+++ b/SignalR.Client/Hubs/SRHubConnection.m
@@ -75,10 +75,12 @@
     }
     return self;
 }
+
 - (void)commonInit {
 	_hubs = [[NSMutableDictionary alloc] init];
 	_callbacks = [[NSMutableDictionary alloc] init];
 }
+
 - (id <SRHubProxyInterface>)createHubProxy:(NSString *)hubName {
     if (self.state != disconnected) {
         [NSException raise:NSInternalInconsistencyException format:NSLocalizedString(@"Proxies cannot be added after the connection has been started.",@"NSInternalInconsistencyException")];


### PR DESCRIPTION
_callbacks wasn't being initialized
registerCallback was using Id was a variable name, also adding the id to the dictionary but returning the wrong id.
