### PR TITLE
Remove AnyJSON dependency by using `NSJSONSerialization` instead

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -34,25 +34,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-   
-### Includes AnyJSON by Mattt Thompson.
-
-Copyright (c) 2012 Mattt Thompson (http://mattt.me/)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.

--- a/Podfile
+++ b/Podfile
@@ -5,12 +5,10 @@ target :"SignalR.Client.iOS", :exclusive => true do
   platform :ios, '6.0'
   pod 'AFNetworking', '~>2.0'
   pod 'SocketRocket', '0.3.1-beta2'
-  pod 'AnyJSON'
 end
 
 target :"SignalR.Client.OSX", :exclusive => true do
   platform :osx, '10.8'
   pod 'AFNetworking', '~>2.0'
   pod 'SocketRocket', '0.3.1-beta2'
-  pod 'AnyJSON', '0.0.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,18 +15,14 @@ PODS:
   - AFNetworking/Serialization (2.0.0)
   - AFNetworking/UIKit (2.0.0):
     - AFNetworking/NSURLConnection
-  - AnyJSON (0.0.1)
   - SocketRocket (0.3.1-beta2)
 
 DEPENDENCIES:
-  - AFNetworking (>= 2.0.0)
-  - AnyJSON
-  - AnyJSON (= 0.0.1)
+  - AFNetworking (~> 2.0)
   - SocketRocket (= 0.3.1-beta2)
 
 SPEC CHECKSUMS:
   AFNetworking: 3fa983b1beaba69566a3374612511e2a6e3fe845
-  AnyJSON: 0a7d4f6da555fe32c6547dd178ddd48dee7d8bae
   SocketRocket: 7ac946bcce46287a791dfff3c1f8daa692821dae
 
-COCOAPODS: 0.25.0
+COCOAPODS: 0.27.1

--- a/README.md
+++ b/README.md
@@ -157,10 +157,6 @@ SignalR-ObjC requires either [iOS 6.0](http://developer.apple.com/library/ios/#r
 - SignalR-ObjC uses [AFNetworking](https://github.com/AFNetworking/AFNetworking).  The minimum supported version of AFNetworking is 2.0.0
 - SignalR-ObjC uses  [SocketRocket](https://github.com/square/SocketRocket).  The minimum supported version of SocketRocket is 0.2.0
 
-### JSON
-
-- SignalR-ObjC uses  [AnyJSON](https://github.com/mattt/AnyJSON).  The minimum supported version of AnyJSON is 0.0.1
-
 
 ## LICENSE
 

--- a/SignalR.Client/Infrastructure/NSObject+SRJSON.m
+++ b/SignalR.Client/Infrastructure/NSObject+SRJSON.m
@@ -20,7 +20,6 @@
 //  DEALINGS IN THE SOFTWARE.
 //
 
-#import "AnyJSON.h"
 #import "NSObject+SRJSON.h"
 
 @implementation NSObject (SRJSON)
@@ -119,7 +118,9 @@ throw:;
 }
 
 - (NSString *)SRJSONRepresentation  {
-    return [[NSString alloc] initWithData:AnyJSONEncode([self ensureFoundationObject:self], nil) encoding:NSUTF8StringEncoding];
+    id object = [self ensureFoundationObject:self];
+    NSData *data = [NSJSONSerialization dataWithJSONObject:object options:(NSJSONWritingOptions)0 error:NULL];
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
 @end
@@ -128,7 +129,8 @@ throw:;
 @implementation NSString (SRJSON)
 
 - (id)SRJSONValue {
-    return AnyJSONDecode([self dataUsingEncoding:NSUTF8StringEncoding],nil);
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    return [NSJSONSerialization JSONObjectWithData:data options:(NSJSONReadingOptions)0 error:NULL];
 }
 
 @end


### PR DESCRIPTION
`NSJSONSerialization` was introduced in iOS 5.0, so it’s time to move away from AnyJSON now. ;-)

Moreover the latest AnyJSON doesn’t compile on arm64, see mattt/AnyJSON#2
