### PR TITLE
web socket abort crash, fixes #162

### DIFF
--- a/SignalR.Client/Transports/SRWebSocketTransport.m
+++ b/SignalR.Client/Transports/SRWebSocketTransport.m
@@ -75,7 +75,7 @@ typedef void (^SRWebSocketStartBlock)(id response, NSError *error);
     }
 }
 
-- (void)abort:(id <SRConnectionInterface>)connection timeout:(NSNumber *)timeout {
+- (void)abort:(id <SRConnectionInterface>)connection timeout:(NSNumber *)timeout connectionData:(NSString *)connectionData {
     [_webSocket setDelegate:nil];
     [_webSocket close];
     _webSocket = nil;


### PR DESCRIPTION
Fixes #162 when calling connection stop on a web socket transport due to incorrect method deceleration.
