### PR TITLE
Fixed server send event stream reader handler

### DIFF
--- a/SignalR.Client/Transports/ServerSentEvents/SREventSourceStreamReader.m
+++ b/SignalR.Client/Transports/ServerSentEvents/SREventSourceStreamReader.m
@@ -86,7 +86,14 @@ typedef enum {
                 [self onOpened];
             } case NSStreamEventHasSpaceAvailable: {
                 if (![self processing]) {
-                    return;
+                  if ([_stream streamStatus] == NSStreamStatusOpen) {
+                      SRLogServerSentEvents(@"Opened");
+
+                      _reading = processing;
+                      [self onOpened];
+                  }
+                  else
+                      return;
                 }
                 
                 NSData *buffer = [stream propertyForKey:NSStreamDataWrittenToMemoryStreamKey];


### PR DESCRIPTION
If the stream is already opened by the time it's passed to the stream reader and getting NSStreamEventOpenCompleted event is in a race condition.

When NSStreamEventHasSpaceAvailable event is handled, it is safe to assume that the stream has already been opened and the reader state m
ust be updated accordingly. Otherwise the stream can never be read.