### PR TITLE
set state to disconnect after failure

### DIFF
--- a/SignalR.Client/SRConnection.m
+++ b/SignalR.Client/SRConnection.m
@@ -152,6 +152,7 @@
             [strongSelf startTransport];
         } else {
             SRLogConnection(@"negotiation failed %@", error);
+            [strongSelf changeState:connecting toState:disconnected];
             [strongSelf didReceiveError:error];
             [strongSelf didClose];
         }
@@ -177,6 +178,7 @@
                 [strongSelf.delegate SRConnectionDidOpen:strongSelf];
             }
         } else {
+            [strongSelf changeState:connecting toState:disconnected];
             [strongSelf didReceiveError:error];
             [strongSelf didClose];
         }


### PR DESCRIPTION
when negotiation or start transport failed state was still connecting. signal r connection could not start again.
