### PR TITLE
Change in signature for SRConnectionStateChangedBlock

### DIFF
--- a/SignalR.Client/SRConnection.h
+++ b/SignalR.Client/SRConnection.h
@@ -36,7 +36,7 @@ typedef void (^SRConnectionErrorBlock)(NSError *);
 typedef void (^SRConnectionClosedBlock)();
 typedef void (^SRConnectionReconnectingBlock)();
 typedef void (^SRConnectionReconnectedBlock)();
-typedef void (^SRConnectionStateChangedBlock)(connectionState);
+typedef void (^SRConnectionStateChangedBlock)(connectionState, connectionState);
 typedef void (^SRConnectionConnectionSlowBlock)();
 
 @interface SRConnection : NSObject <SRConnectionInterface>

--- a/SignalR.Client/SRConnection.m
+++ b/SignalR.Client/SRConnection.m
@@ -196,7 +196,7 @@
             SRLogConnectionDebug(@"connection state did change from %u to %u", oldState, newState);
             
             if (self.stateChanged){
-                self.stateChanged(self.state);
+                self.stateChanged(oldState, newState);
             }
             
             if (self.delegate && [self.delegate respondsToSelector:@selector(SRConnection:didChangeState:newState:)]) {


### PR DESCRIPTION
## Proposed Change

Changed signature for SRConnectionStateChangedBlock for passing oldState along with newState.
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
## Further comments

Delegate method specifies both oldState and newState when connection state changes. Similar change is done for the block.
